### PR TITLE
Fix: Todoist API fails when adding too many sections

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.5
+current_version = 0.3.6
 commit = True
 tag = True
 

--- a/AppLambda/src/config.py
+++ b/AppLambda/src/config.py
@@ -2,7 +2,7 @@ import os
 
 ### About ###
 APP_TITLE = "Unified Shopping List"
-APP_VERSION = "0.3.5"
+APP_VERSION = "0.3.6"
 INTERNAL_APP_NAME = "shopping_list_api"
 
 

--- a/AppLambda/src/static/templates/_base.html
+++ b/AppLambda/src/static/templates/_base.html
@@ -90,7 +90,7 @@
     <!-- Footer -->
     <footer class="fixed-bottom">
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <span class="navbar-text px-2 border-end">App Version 0.3.5</span>
+        <span class="navbar-text px-2 border-end">App Version 0.3.6</span>
         <ul class="navbar-nav me-auto">
           <li class="nav-item">
             <a class='{{ "nav-link active" if active_page == "privacy_policy" else "nav-link" }}' href='{{ url_for("privacy_policy") }}'>Privacy Policy</a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Unified Shopping List"
-version = "0.3.5"
+version = "0.3.6"
 description = "Open source app to connect your shopping lists in real time"
 authors = ["Michael Genson <71845777+michael-genson@users.noreply.github.com>"]
 license = "GNU"

--- a/tests/service_tests/test_todoist_task_service.py
+++ b/tests/service_tests/test_todoist_task_service.py
@@ -61,6 +61,7 @@ def test_todoist_task_service_is_default_section(
 
     default_section_name = todoist_task_service.config.default_section_name
     default_section = todoist_task_service.get_section(default_section_name, project_id=data.project.id)
+    assert default_section
     assert todoist_task_service.is_default_section(default_section.id, data.project.id)
 
 
@@ -94,9 +95,11 @@ def test_todoist_task_service_is_task_section(
     default_section = todoist_task_service.get_section(
         todoist_task_service.config.default_section_name, data.project.id
     )
+    assert default_section
     task_with_default_section.section_id = default_section.id
 
     random_section = todoist_task_service.get_section(random_string(), data.project.id)
+    assert random_section
 
     # even when sections don't match, we consider them matching when not using sections,
     # so all of these scenarios should only be True if we are not using sections
@@ -484,6 +487,7 @@ def test_todoist_task_service_update_task_with_new_section(
         assert updated_task.section_id == original_task.section_id
     else:
         new_section = todoist_task_service.get_section(new_section_name, project_id=data.project.id)
+        assert new_section
         assert updated_task.section_id == new_section.id != original_task.section_id
 
         # updating a task's section actually closes/deletes the existing task and adds a new task,


### PR DESCRIPTION
This is a quick fix for the `403` too many sections error. Added `TODO` items for a proper fix