### PR TITLE
fix: Sanitize Mealie URL In Config

### DIFF
--- a/AppLambda/src/models/account_linking.py
+++ b/AppLambda/src/models/account_linking.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractproperty
 from typing import Callable, ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from ._base import APIBase, as_form
 
@@ -74,6 +74,19 @@ class UserMealieConfiguration(UserMealieConfigurationUpdate, UserConfigurationBa
     notifier_id: str
     security_hash: str
     """Unencrypted random hash to verify notifications"""
+
+    @validator("base_url")
+    def validate_base_url(cls, v: str):
+        if not v:
+            raise ValueError("base_url must not be empty")
+
+        if v[-1] != "/":
+            v += "/"
+
+        if "http" not in v:
+            v = "https://" + v
+
+        return v
 
     @property
     def is_valid(self):

--- a/AppLambda/src/services/mealie.py
+++ b/AppLambda/src/services/mealie.py
@@ -76,7 +76,7 @@ class MealieListService:
         if not recipe:
             return None
 
-        return f"{self.config.base_url}/recipe/{recipe.slug}"
+        return f"{self.config.base_url}recipe/{recipe.slug}"
 
     @cache
     def get_food(self, food: str) -> Food | None:

--- a/tests/model_tests/test_account_linking_models.py
+++ b/tests/model_tests/test_account_linking_models.py
@@ -1,0 +1,27 @@
+import pytest
+
+from AppLambda.src.models.account_linking import UserMealieConfiguration
+from tests.utils.generators import random_string
+
+
+@pytest.mark.parametrize(
+    "url_input, expected_url",
+    [
+        ("https://example.com/", "https://example.com/"),
+        ("http://example.com/", "http://example.com/"),
+        ("example.com/", "https://example.com/"),
+        ("https://example.com", "https://example.com/"),
+        ("http://example.com", "http://example.com/"),
+        ("example.com", "https://example.com/"),
+    ],
+)
+def test_user_mealie_configuration_sanitizes_mealie_base_url(url_input: str, expected_url: str):
+    config = UserMealieConfiguration(
+        base_url=url_input,
+        auth_token=random_string(),
+        auth_token_id=random_string(),
+        notifier_id=random_string(),
+        security_hash=random_string(),
+    )
+
+    assert config.base_url == expected_url

--- a/tests/service_tests/test_mealie_list_service.py
+++ b/tests/service_tests/test_mealie_list_service.py
@@ -48,7 +48,7 @@ def test_mealie_list_service_label_store(mealie_list_service: MealieListService,
 
 def test_mealie_list_service_get_recipe_url(mealie_list_service: MealieListService, mealie_recipes: list[MealieRecipe]):
     for recipe in mealie_recipes:
-        expected_url = f"{mealie_list_service.config.base_url}/recipe/{recipe.slug}"
+        expected_url = f"{mealie_list_service.config.base_url}recipe/{recipe.slug}"
         recipe_url = mealie_list_service.get_recipe_url(recipe.id)
         assert recipe_url
         assert recipe_url == expected_url


### PR DESCRIPTION
This sanitizes the Mealie URL in the Mealie user config to make it consistent (i.e. make sure it has `http` and ends with a trailing slash). This fixes an issue where the Mealie recipe URL in Todoist doesn't work due to having the wrong number of slashes.

Fixes https://github.com/michael-genson/Unified-Shopping-List/issues/33