### PR TITLE
feat: Leverage Mealie Food Aliases to Match Foods

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,17 +34,9 @@
                 },
                 "python.defaultInterpreterPath": "/usr/local/bin/python",
                 "python.languageServer": "Default",
-                "python.linting.enabled": true,
-                "python.linting.pylintEnabled": true,
                 "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
                 "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
                 "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-                "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-                "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-                "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-                "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-                "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-                "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
             },
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,5 @@
 {
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "python.linting.mypyArgs": [
-    "--follow-imports=silent",
-    "--show-column-numbers",
-    "--disallow-untyped-defs",
-    "--disallow-untyped-calls",
-  ],
-  "python.linting.pylintArgs": [
-    "--enable=W0614"
-  ],
   "explorer.fileNesting.enabled": true,
-  "python.formatting.provider": "black",
-  "isort.args": [
-    "--profile",
-    "black"
-  ],
   "explorer.fileNesting.patterns": {
     "package.json": "package-lock.json, yarn.lock, .eslintrc.js, tsconfig.json, .prettierrc, .editorconfig",
     "pyproject.toml": "poetry.lock, alembic.ini, .pylintrc, .flake8, .bumpversion.cfg",

--- a/AppLambda/src/models/mealie.py
+++ b/AppLambda/src/models/mealie.py
@@ -85,11 +85,22 @@ class Label(MealieBase):
         return self.name
 
 
+class UnitFoodAlias(MealieBase):
+    name: str
+
+
 class UnitFoodBase(MealieBase):
     name: str
     plural_name: str | None = None
     description: str = ""
     extras: dict | None = {}
+
+    aliases: list[UnitFoodAlias] | None = None
+    """
+    List of aliases for this unit/food
+
+    Only available in v1.0.0-RC2 and later
+    """
 
 
 class Unit(UnitFoodBase):

--- a/AppLambda/src/services/mealie.py
+++ b/AppLambda/src/services/mealie.py
@@ -61,7 +61,14 @@ class MealieListService:
     def food_store(self) -> dict[str, Food]:
         """Dictionary of { food.name.lower(): Food }"""
 
-        return {food.name.lower(): food for food in self._client.get_all_foods()}
+        store: dict[str, Food] = {}
+        all_foods = self._client.get_all_foods()
+        for food in all_foods:
+            store[food.name.lower()] = food
+            for alias in food.aliases or []:
+                store[alias.name.lower()] = food
+
+        return store
 
     @cached_property
     def label_store(self) -> dict[str, Label]:


### PR DESCRIPTION
This PR adds entries for food aliases when fuzzy-matching against the Mealie food store. Food aliases have been supported by Mealie since v1.0.0 RC2.